### PR TITLE
Added events view

### DIFF
--- a/levelup/urls.py
+++ b/levelup/urls.py
@@ -2,10 +2,11 @@ from django.contrib import admin
 from django.conf.urls import include
 from rest_framework import routers
 from django.urls import path
-from levelupapi.views import register_user, login_user, GameTypeView
+from levelupapi.views import register_user, login_user, GameTypeView, EventView
 
 router = routers.DefaultRouter(trailing_slash=False) # trailing_slash=False tells
 router.register(r'gametypes', GameTypeView, 'gametype')
+router.register(r'events', EventView, 'event')
 
 urlpatterns = [
     path('', include(router.urls)),

--- a/levelupapi/views/__init__.py
+++ b/levelupapi/views/__init__.py
@@ -1,2 +1,3 @@
 from .auth import login_user, register_user
 from .game_types import GameTypeView
+from .events import EventView

--- a/levelupapi/views/events.py
+++ b/levelupapi/views/events.py
@@ -1,0 +1,66 @@
+"""View module for handling requests about events"""
+from rest_framework.viewsets import ViewSet
+from rest_framework.response import Response
+from rest_framework import serializers, status
+from levelupapi.models import Event
+from django.contrib.auth.models import User
+    
+
+class EventView(ViewSet):
+    """Level up events view"""
+
+    def retrieve(self, request, pk):
+        """Handle GET requests for single event
+        
+        Returns -- JSON serialized event
+        """
+
+        try:
+            event = Event.objects.get(pk=pk)
+            serializer = EventSerializer(event)
+            return Response(serializer.data)
+        except Event.DoesNotExist:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+    def list(self, request):
+        """Handle GET requests to get all events
+
+        Returns:
+            Response -- JSON serialized list of events
+        """
+
+        events = Event.objects.all()
+        serializer = EventSerializer(events, many=True)
+        return Response(serializer.data)
+
+
+class EventOrganizerSerializer(serializers.ModelSerializer):
+    """JSON serializer for event organizers"""
+    full_name = serializers.SerializerMethodField()
+
+    def get_full_name(self, obj):
+        return f'{obj.first_name} {obj.last_name}'
+
+    class Meta:
+        model = User
+        fields = ('id', 'full_name')
+
+
+class EventSerializer(serializers.ModelSerializer):
+    """JSON serializer for events"""
+
+    date = serializers.SerializerMethodField()
+    time = serializers.SerializerMethodField()
+    organizer = EventOrganizerSerializer(many=False)
+    attendees = EventOrganizerSerializer(many=True)
+
+    def get_date(self, obj):
+        return obj.date_time.date().strftime("%Y-%m-%d")
+
+    def get_time(self, obj):
+        return obj.date_time.time().strftime("%I:%M %p")
+
+
+    class Meta:
+        model = Event
+        fields = ('id', 'name', 'date', 'time', 'organizer', 'game', 'attendees')


### PR DESCRIPTION
Added `events` view with a `list` and a `retrieve` method.

Supported routes
`/events` Will return all events information
`/events/n` will return a single event with it's information

## Steps to test
### All Events
1. Pull down the event-view branch and switch to it
2. If your debugger is running, restart it
3. Open Postman
4. Request `http://localhost:8000/events` and verify that you get an array of events in the response, and that each one has the following keys on it
    - id
    - name
    - date
    - time
    - organizer
    - game id (will edit later)
    - a list of attendees
5. Also verify that the response code is 200

### Single Events
1.  Request `http://localhost:8000/events/n` and verify that you get an event object in the response, and that it has the following keys on it
    - id
    - name
    - date
    - time
    - organizer
    - game id (will edit later)
    - a list of attendees
2. Also verify that the response code is 200